### PR TITLE
Add Rackspace Spot provider and tee-bot cloudspace module

### DIFF
--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -32,6 +32,8 @@ jobs:
       # Supabase provider vars — only consumed by the supabase root; ignored elsewhere.
       TF_VAR_supabase_access_token: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       TF_VAR_supabase_organization_id: ${{ secrets.SUPABASE_ORGANIZATION_ID }}
+      # Rackspace Spot provider var — only consumed by the tee-bot root; ignored elsewhere.
+      TF_VAR_rackspace_spot_token: ${{ secrets.TF_VAR_RACKSPACE_SPOT_TOKEN }}
 
     steps:
     - name: Checkout code

--- a/.github/workflows/staging_apply.yml
+++ b/.github/workflows/staging_apply.yml
@@ -48,3 +48,11 @@ jobs:
       working_directory: ./env/staging/brackets-app
       auto_apply: true
     secrets: inherit
+
+  staging-tee-bot:
+    uses: ./.github/workflows/shared.yml
+    with:
+      environment: staging
+      working_directory: ./env/staging/tee-bot
+      auto_apply: true
+    secrets: inherit

--- a/.github/workflows/staging_plan.yml
+++ b/.github/workflows/staging_plan.yml
@@ -48,3 +48,11 @@ jobs:
       working_directory: ./env/staging/brackets-app
       auto_apply: false
     secrets: inherit
+
+  staging-tee-bot:
+    uses: ./.github/workflows/shared.yml
+    with:
+      environment: staging
+      working_directory: ./env/staging/tee-bot
+      auto_apply: false
+    secrets: inherit

--- a/env/staging/tee-bot/main.tf
+++ b/env/staging/tee-bot/main.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    spot = {
+      source = "rackerlabs/spot"
+    }
+  }
+  backend "s3" {
+    bucket  = "staging-terraform-state-12093"
+    key     = "staging/tee-bot/terraform.tfstate"
+    region  = "us-east-2"
+    encrypt = true
+  }
+}
+
+variable "rackspace_spot_token" {
+  description = "Rackspace Spot authentication token"
+  type        = string
+  sensitive   = true
+}
+
+provider "spot" {
+  token = var.rackspace_spot_token
+}
+
+module "tee_bot" {
+  source = "../../../modules/tee-bot"
+}

--- a/env/staging/tee-bot/outputs.tf
+++ b/env/staging/tee-bot/outputs.tf
@@ -1,0 +1,4 @@
+output "kubeconfig_raw" {
+  value     = module.tee_bot.kubeconfig_raw
+  sensitive = true
+}

--- a/modules/tee-bot/main.tf
+++ b/modules/tee-bot/main.tf
@@ -1,0 +1,43 @@
+resource "spot_cloudspace" "tee_bot" {
+  name   = var.cloudspace_name
+  region = var.region
+
+  # CNI: keep default calico unless you know you need something else.
+  # cni = "calico"
+}
+
+resource "spot_spotnodepool" "core" {
+  cloudspace_name = spot_cloudspace.tee_bot.name
+  name            = "core-spot"
+
+  server_class = var.core_server_class
+  bid_price    = var.core_bid_price
+
+  desired_nodes = var.core_desired_nodes
+
+  labels = {
+    "capacity-type" = "spot"
+    "pool"          = "core"
+    "workload-tier" = "baseline"
+  }
+}
+
+resource "spot_spotnodepool" "workers_spot" {
+  cloudspace_name = spot_cloudspace.tee_bot.name
+  name            = "workers-spot"
+
+  server_class = var.workers_server_class
+  bid_price    = var.workers_bid_price
+
+  desired_nodes = var.workers_desired_nodes
+
+  labels = {
+    "capacity-type" = "spot"
+    "pool"          = "workers"
+    "workload-tier" = "burst"
+  }
+}
+
+data "spot_kubeconfig" "tee_bot" {
+  cloudspace_name = spot_cloudspace.tee_bot.name
+}

--- a/modules/tee-bot/outputs.tf
+++ b/modules/tee-bot/outputs.tf
@@ -1,0 +1,8 @@
+output "kubeconfig_raw" {
+  value     = data.spot_kubeconfig.tee_bot.raw
+  sensitive = true
+}
+
+output "cloudspace_name" {
+  value = spot_cloudspace.tee_bot.name
+}

--- a/modules/tee-bot/variables.tf
+++ b/modules/tee-bot/variables.tf
@@ -1,0 +1,47 @@
+variable "cloudspace_name" {
+  type        = string
+  default     = "tee-bot-dev"
+  description = "Name of the Rackspace Spot cloudspace."
+}
+
+variable "region" {
+  type        = string
+  default     = "us-central-dfw-2"
+  description = "Rackspace Spot region for the cloudspace."
+}
+
+variable "core_server_class" {
+  type        = string
+  default     = "gp.vs2.medium-dfw2"
+  description = "Server class for the core nodepool."
+}
+
+variable "core_bid_price" {
+  type        = number
+  default     = 0.02
+  description = "Bid price for the core nodepool. Temporary: core runs on spot for now, switch back to on-demand later."
+}
+
+variable "core_desired_nodes" {
+  type        = number
+  default     = 1
+  description = "Desired node count for the core nodepool."
+}
+
+variable "workers_server_class" {
+  type        = string
+  default     = "gp.vs2.medium-dfw2"
+  description = "Server class for the spot workers nodepool."
+}
+
+variable "workers_bid_price" {
+  type        = number
+  default     = 0.02
+  description = "Bid price for the spot workers nodepool. Tune to your comfort."
+}
+
+variable "workers_desired_nodes" {
+  type        = number
+  default     = 2
+  description = "Desired node count for the spot workers nodepool."
+}


### PR DESCRIPTION
## Summary
- Adds a `tee-bot` module provisioning a Rackspace Spot cloudspace, core + worker nodepools, and a kubeconfig data source
- Core nodepool runs on spot pricing temporarily (was on-demand)
- Adds the `staging/tee-bot` root with the spot provider/token wiring
- Adds `staging-tee-bot` jobs to the plan/apply CI workflows and forwards `TF_VAR_rackspace_spot_token` from the `TF_VAR_RACKSPACE_SPOT_TOKEN` secret

## Test plan
- [ ] CI plan job (`staging-tee-bot`) runs cleanly on this PR
- [ ] Review plan output for the new cloudspace/nodepools before merge