### PR TITLE
Fix tee-bot module provider source for spot

### DIFF
--- a/modules/tee-bot/main.tf
+++ b/modules/tee-bot/main.tf
@@ -1,3 +1,11 @@
+terraform {
+  required_providers {
+    spot = {
+      source = "rackerlabs/spot"
+    }
+  }
+}
+
 resource "spot_cloudspace" "tee_bot" {
   name   = var.cloudspace_name
   region = var.region


### PR DESCRIPTION
Declares required_providers in the tee-bot module so its spot provider reference resolves to rackerlabs/spot instead of defaulting to hashicorp/spot, which tofu init couldn't find in the registry.