### PR TITLE
Add ECR repo for tee-bot with GitHub Actions OIDC push role

### DIFF
--- a/env/staging/tee-bot/main.tf
+++ b/env/staging/tee-bot/main.tf
@@ -5,6 +5,10 @@ terraform {
     spot = {
       source = "rackerlabs/spot"
     }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
   }
   backend "s3" {
     bucket  = "staging-terraform-state-12093"
@@ -24,6 +28,22 @@ provider "spot" {
   token = var.rackspace_spot_token
 }
 
+provider "aws" {
+  region = "us-east-2"
+  default_tags {
+    tags = {
+      Environment = "staging"
+      ManagedBy   = "OpenTofu"
+    }
+  }
+}
+
 module "tee_bot" {
   source = "../../../modules/tee-bot"
+
+  github_actions_ecr_push_repositories = ["brisipin/sass-bot"]
+
+  tags = {
+    App = "tee-bot"
+  }
 }

--- a/env/staging/tee-bot/outputs.tf
+++ b/env/staging/tee-bot/outputs.tf
@@ -2,3 +2,11 @@ output "kubeconfig_raw" {
   value     = module.tee_bot.kubeconfig_raw
   sensitive = true
 }
+
+output "ecr_repository_url" {
+  value = module.tee_bot.ecr_repository_url
+}
+
+output "ecr_push_role_arn" {
+  value = module.tee_bot.ecr_push_role_arn
+}

--- a/modules/tee-bot/ecr.tf
+++ b/modules/tee-bot/ecr.tf
@@ -1,0 +1,30 @@
+resource "aws_ecr_repository" "teebot" {
+  name                 = "teebot"
+  image_tag_mutability = "MUTABLE"
+  force_delete         = true
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "teebot" {
+  repository = aws_ecr_repository.teebot.name
+
+  policy = jsonencode({
+    rules = [{
+      rulePriority = 1
+      description  = "Keep last 10 images"
+      selection = {
+        tagStatus   = "any"
+        countType   = "imageCountMoreThan"
+        countNumber = 10
+      }
+      action = { type = "expire" }
+    }]
+  })
+}

--- a/modules/tee-bot/github_oidc_ecr_push.tf
+++ b/modules/tee-bot/github_oidc_ecr_push.tf
@@ -1,0 +1,72 @@
+resource "aws_iam_openid_connect_provider" "github" {
+  count = length(var.github_actions_ecr_push_repositories) > 0 && var.create_github_oidc_provider ? 1 : 0
+
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1", "1c58a3a8518e8759bf075b76b750d4f2df264fcd"]
+  tags            = var.tags
+}
+
+data "aws_iam_openid_connect_provider" "github" {
+  count = length(var.github_actions_ecr_push_repositories) > 0 && var.github_oidc_provider_arn == "" && !var.create_github_oidc_provider ? 1 : 0
+  url   = "https://token.actions.githubusercontent.com"
+}
+
+resource "aws_iam_role" "github_ecr_push" {
+  count = length(var.github_actions_ecr_push_repositories) > 0 ? 1 : 0
+
+  name_prefix = "teebot-gh-ecr-"
+  description = "GitHub Actions OIDC can assume this role to push images to the teebot ECR repo."
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = "sts:AssumeRoleWithWebIdentity"
+      Principal = {
+        Federated = local.github_oidc_provider_arn_resolved
+      }
+      Condition = {
+        StringEquals = {
+          "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+        }
+        StringLike = {
+          "token.actions.githubusercontent.com:sub" = local.github_oidc_subject_patterns
+        }
+      }
+    }]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy" "github_ecr_push" {
+  count = length(var.github_actions_ecr_push_repositories) > 0 ? 1 : 0
+
+  name_prefix = "ecr-push-"
+  role        = aws_iam_role.github_ecr_push[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["ecr:GetAuthorizationToken"]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+          "ecr:PutImage",
+          "ecr:InitiateLayerUpload",
+          "ecr:UploadLayerPart",
+          "ecr:CompleteLayerUpload"
+        ]
+        Resource = aws_ecr_repository.teebot.arn
+      }
+    ]
+  })
+}

--- a/modules/tee-bot/locals.tf
+++ b/modules/tee-bot/locals.tf
@@ -1,0 +1,8 @@
+locals {
+  github_oidc_provider_arn_resolved = length(var.github_actions_ecr_push_repositories) == 0 ? "" : (
+    var.github_oidc_provider_arn != "" ? var.github_oidc_provider_arn : (
+      var.create_github_oidc_provider ? aws_iam_openid_connect_provider.github[0].arn : data.aws_iam_openid_connect_provider.github[0].arn
+    )
+  )
+  github_oidc_subject_patterns = [for r in var.github_actions_ecr_push_repositories : "repo:${r}:*"]
+}

--- a/modules/tee-bot/main.tf
+++ b/modules/tee-bot/main.tf
@@ -3,6 +3,10 @@ terraform {
     spot = {
       source = "rackerlabs/spot"
     }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
   }
 }
 

--- a/modules/tee-bot/outputs.tf
+++ b/modules/tee-bot/outputs.tf
@@ -6,3 +6,17 @@ output "kubeconfig_raw" {
 output "cloudspace_name" {
   value = spot_cloudspace.tee_bot.name
 }
+
+output "ecr_repository_url" {
+  value       = aws_ecr_repository.teebot.repository_url
+  description = "docker build && docker push target after aws ecr get-login-password."
+}
+
+output "ecr_repository_arn" {
+  value = aws_ecr_repository.teebot.arn
+}
+
+output "ecr_push_role_arn" {
+  value       = length(aws_iam_role.github_ecr_push) > 0 ? aws_iam_role.github_ecr_push[0].arn : null
+  description = "Assume this role from GitHub Actions (oidc) to push images. Null if github_actions_ecr_push_repositories is empty."
+}

--- a/modules/tee-bot/variables.tf
+++ b/modules/tee-bot/variables.tf
@@ -45,3 +45,27 @@ variable "workers_desired_nodes" {
   default     = 2
   description = "Desired node count for the spot workers nodepool."
 }
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Extra tags for AWS resources."
+}
+
+variable "github_actions_ecr_push_repositories" {
+  type        = list(string)
+  default     = []
+  description = "GitHub repos allowed to assume the ECR push role (e.g. [\"myorg/my-backend\"]). Empty = no push role."
+}
+
+variable "create_github_oidc_provider" {
+  type        = bool
+  default     = false
+  description = "Create account-level GitHub OIDC provider. Set true only if it does not exist yet (one per AWS account)."
+}
+
+variable "github_oidc_provider_arn" {
+  type        = string
+  default     = ""
+  description = "Existing IAM OIDC provider ARN for https://token.actions.githubusercontent.com. Overrides lookup/create when set."
+}


### PR DESCRIPTION
Creates an ECR repository named "teebot" and an IAM role that brisipin/sass-bot can assume via GitHub Actions OIDC to push images.