### PR TITLE
Add pull-only IAM user for teebot ECR repo

### DIFF
--- a/env/staging/tee-bot/outputs.tf
+++ b/env/staging/tee-bot/outputs.tf
@@ -10,3 +10,12 @@ output "ecr_repository_url" {
 output "ecr_push_role_arn" {
   value = module.tee_bot.ecr_push_role_arn
 }
+
+output "ecr_pull_access_key_id" {
+  value = module.tee_bot.ecr_pull_access_key_id
+}
+
+output "ecr_pull_secret_access_key" {
+  value     = module.tee_bot.ecr_pull_secret_access_key
+  sensitive = true
+}

--- a/modules/tee-bot/ecr_pull.tf
+++ b/modules/tee-bot/ecr_pull.tf
@@ -1,0 +1,41 @@
+# Rackspace Spot cloudspace nodes have no AWS identity (unlike EKS, there's no
+# IRSA / instance-profile path), so pulling from the private teebot ECR repo
+# needs a static-credential IAM principal. Scoped to pull-only on this one
+# repo. The access key is consumed by an in-cluster CronJob that refreshes a
+# Kubernetes imagePullSecret (ECR auth tokens expire every 12h) — see
+# sass-bot/deploy/staging.
+resource "aws_iam_user" "teebot_ecr_pull" {
+  name = "teebot-ecr-pull"
+  tags = var.tags
+}
+
+resource "aws_iam_user_policy" "teebot_ecr_pull" {
+  name = "ecr-pull"
+  user = aws_iam_user.teebot_ecr_pull.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "EcrAuth"
+        Effect   = "Allow"
+        Action   = ["ecr:GetAuthorizationToken"]
+        Resource = "*"
+      },
+      {
+        Sid    = "EcrPull"
+        Effect = "Allow"
+        Action = [
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+        ]
+        Resource = aws_ecr_repository.teebot.arn
+      }
+    ]
+  })
+}
+
+resource "aws_iam_access_key" "teebot_ecr_pull" {
+  user = aws_iam_user.teebot_ecr_pull.name
+}

--- a/modules/tee-bot/outputs.tf
+++ b/modules/tee-bot/outputs.tf
@@ -20,3 +20,14 @@ output "ecr_push_role_arn" {
   value       = length(aws_iam_role.github_ecr_push) > 0 ? aws_iam_role.github_ecr_push[0].arn : null
   description = "Assume this role from GitHub Actions (oidc) to push images. Null if github_actions_ecr_push_repositories is empty."
 }
+
+output "ecr_pull_access_key_id" {
+  value       = aws_iam_access_key.teebot_ecr_pull.id
+  description = "Access key for the pull-only IAM user. Feed into the in-cluster ECR cred-sync CronJob, not committed anywhere."
+}
+
+output "ecr_pull_secret_access_key" {
+  value       = aws_iam_access_key.teebot_ecr_pull.secret
+  sensitive   = true
+  description = "Secret key for the pull-only IAM user. Retrieve with `tofu output -raw ecr_pull_secret_access_key`."
+}


### PR DESCRIPTION
## Summary
- Adds a pull-only IAM user (teebot-ecr-pull) scoped to GetAuthorizationToken plus the three pull actions on just the teebot repo ARN.
- Rackspace Spot cloudspace nodes have no AWS identity (no IRSA/instance-profile path), so this static-credential principal is what the in-cluster cred-sync CronJob in brisipin/sass-bot (deploy/staging/ecr-cred-sync.yaml) uses to keep the cluster's ECR pull secret refreshed.
- Exposes ecr_pull_access_key_id / ecr_pull_secret_access_key as module and env outputs for the one-time bootstrap step.

Companion change: brisipin/sass-bot#3

## Test plan
- [x] `tofu validate` passes for modules/tee-bot
- [ ] `tofu apply` in env/staging/tee-bot, then bootstrap the k8s secret per sass-bot's deploy/staging/README.md